### PR TITLE
Enable workflow env variables

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -1,5 +1,12 @@
 on:
   workflow_call:
+    inputs:
+      env-vars:
+        description: 'Multiline list of KEY=VALUE pairs to set in the environment'
+        required: false
+        default: ''
+        type: string
+
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,6 +28,12 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny,cargo-udeps,cargo-audit,cargo-outdated,cargo-pants,osv-scanner,taplo
+
+      - name: Set dynamic environment variables
+        if: ${{ inputs['env-vars'] != '' }}
+        shell: bash
+        run: |
+          echo "${{ inputs['env-vars'] }}" | sed '/^\s*$/d' >> $GITHUB_ENV
 
       - name: Lint
         run: |

--- a/.github/workflows/solidity-check.yml
+++ b/.github/workflows/solidity-check.yml
@@ -11,9 +11,11 @@ on:
         required: false
         default: true
         description: whether to run integration tests
-    secrets:
-      ETHEREUM_RPC_URL:
+      env-vars:
+        description: 'Multiline list of KEY=VALUE pairs to set in the environment'
         required: false
+        default: ''
+        type: string
           
 jobs:
   contracts-unit-tests:
@@ -23,6 +25,13 @@ jobs:
         with:
           submodules: recursive
       
+      - name: Set dynamic environment variables
+        if: ${{ inputs['env-vars'] != '' }}
+        shell: bash
+        run: |
+          echo "${{ inputs['env-vars'] }}" | sed '/^\s*$/d' >> $GITHUB_ENV
+
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         


### PR DESCRIPTION
Whilst this works at a higher level for passing things down. What github actions won't allow you to do is pass a secret as a string through with.


This will work fine
```
jobs:
  rust:
    uses: spire-labs/workflows/.github/workflows/rust-check.yml@main
    with:
      env-vars: |
        FOO="bar"
```
This does not
```
jobs:
  rust:
    uses: spire-labs/workflows/.github/workflows/rust-check.yml@main
    with:
      env-vars: |
        FOO="${{secrets.FOO}}"
```

Neither does this

```
jobs:
  rust:
    uses: spire-labs/workflows/.github/workflows/rust-check.yml@main
    with:
      env-vars: |
        FOO="${{env.FOO}}"
```

I can understand the restriction not wanting to leak secrets into third-party workflows, but what I really want is a way to say. I accept responsibility for this, I understand whats going on etc.