### PR TITLE
add in audit security check

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -63,10 +63,15 @@ jobs:
           taplo fmt --check
       
 
-      - name: Security Check
+      - name: Cargo Deny Check
         continue-on-error: ${{ inputs['continue-on-security-error'] }}
         run: |
           cargo deny check --hide-inclusion-graph
+
+      - name: Cargo Audit Check
+        continue-on-error: ${{ inputs['continue-on-security-error'] }}
+        run: |
+          cargo audit
 
       - name: Test
         shell: bash


### PR DESCRIPTION
Cargo deny doesn't cover all CVE checks (I have no idea why), presumably there's some difference in the CVE database that is being used and the way it scans the cargo lock file. 

Either way, we need an additional CVE check, which is what `cargo pants` was doing. If that tool isn't appropriate (the log output was too large for github workers to handle), then we should use something else. 

If there are advisories we wish to ignore, then we should explicitly add them to the config for that repository with reasons why.