### PR TITLE
ci: support private submodule checkout

### DIFF
--- a/.github/workflows/solidity-check.yml
+++ b/.github/workflows/solidity-check.yml
@@ -21,15 +21,47 @@ on:
         required: false
         default: false
         description: whether to use Bun instead of Foundry for package management
+      private-submodule-repositories:
+        type: string
+        required: false
+        default: ""
+        description: "Newline-separated repositories to include in a GitHub App token for private submodules"
+      ci-submodules-app-client-id:
+        type: string
+        required: false
+        default: ""
+        description: "GitHub App client ID used to read private submodules"
+    secrets:
+      ci_submodules_app_private_key:
+        required: false
           
 jobs:
   check:
     name: "Solidity Check"
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App installation token
+        if: ${{ inputs.private-submodule-repositories != '' }}
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ inputs.ci-submodules-app-client-id }}
+          private-key: ${{ secrets.ci_submodules_app_private_key }}
+          owner: spire-labs
+          repositories: ${{ inputs.private-submodule-repositories }}
+          permission-contents: read
+
       - uses: actions/checkout@v4
+        if: ${{ inputs.private-submodule-repositories == '' }}
         with:
           submodules: recursive
+
+      - uses: actions/checkout@v4
+        if: ${{ inputs.private-submodule-repositories != '' }}
+        with:
+          persist-credentials: false
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
       
       - name: Set dynamic environment variables
         if: ${{ inputs['env-vars'] != '' }}


### PR DESCRIPTION
## Summary

The shared Solidity check now supports private contract repositories, so callers can run recursive checkout with a short-lived GitHub App token.

Existing callers keep the current unauthenticated checkout path when they omit the new inputs, so public repositories keep the same setup.

Pylon can pass its private contract repository list to this reusable GitHub Actions job, so Solidity checks can fetch BaiBai contract source on clean runners.

## New Reusable Job Inputs

Callers can pass a newline-separated repository list for the app token:

```yaml
private-submodule-repositories: |
  pylon
  baibai-contracts
```

Callers can pass the GitHub App client ID as a normal input:

```yaml
ci-submodules-app-client-id: ${{ vars.CI_SUBMODULES_APP_CLIENT_ID }}
```

Callers can pass the GitHub App private key as a secret:

```yaml
secrets:
  ci_submodules_app_private_key: ${{ secrets.CI_SUBMODULES_APP_PRIVATE_KEY }}
```

## Checkout Behavior

When `private-submodule-repositories` is empty, the job performs the same recursive checkout that public repositories already use.

When `private-submodule-repositories` has repository names, the job mints a GitHub App token with `contents: read` and passes that token to recursive checkout.

The checkout token grants read access only to the repositories requested by the caller, so private contract source is available without broad repository access.

## Compatibility

Public callers need no YAML changes because all new inputs default to empty values.

Private callers must provide the repository list, client ID, and private key secret before recursive checkout can read private repositories.

## Verification

`actionlint` passed for this reusable GitHub Actions job after filtering stale local metadata for `actions/create-github-app-token@v3`.

`git diff --check` passed, so whitespace errors are absent.

The action metadata for `actions/create-github-app-token@v3` lists `client-id`, so the new token step uses the current input name.
